### PR TITLE
nVidia Fermi note

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Notes:
 * Minimum requirements for Dota 2 Vulkan:
  * Windows 7/8/10 64-bit: NVIDIA Kepler-series+ (365.19+ driver), AMD 7700+ (Crimson 16.5.2.1+ driver)
  * Linux 64-bit: NVIDIA Kepler-series+ (364.16+ driver), AMD GCN 1.2 (16.20.3 driver)
-   * NOTE: NVIDIA __Fermi GPUs are not supported__, this includes some models in the 600/700/800 series, so please make sure you have a Kepler (GKxxx), Maxwell (GMxxx), or Pascal (GPxxx) GPU before posting a bug.  This is especially confusing because some models such as the GT730 have both a Fermi and Kepler model.  You can check for sure by looking up your [NVIDIA PCI Device ID] (https://pci-ids.ucw.cz/read/PC/10de).  The Device ID can be found in Steam -> Help -> System Information.
+ * __NOTE: NVIDIA's driver does not support Vulkan on Fermi GPUs__, this includes some low end models in the 600/700/800 series, so please make sure you have a Kepler (GKxxx), Maxwell (GMxxx), or Pascal (GPxxx) GPU before posting a bug.  This is especially confusing because some models such as the GT730 have both a Fermi and Kepler model.  You can check for sure by looking up your [NVIDIA PCI Device ID] (https://pci-ids.ucw.cz/read/PC/10de).  The Device ID can be found in ```Steam``` -> ```Help``` -> ```System Information```.
  * 2GB of GPU Memory required - may experience crashes with < 2GB of GPU memory.
  * Vulkan is not supported on Mac OS X.
 


### PR DESCRIPTION
A couple adjustments: un-indent the nvidia note so it does not look like a sub-section of linux. Make the distinction that it's the nvidia driver that is lacking support, not the hardware.